### PR TITLE
DRS: Make sure to only enable when supported

### DIFF
--- a/src/sonyxperiadev/extendedsettings/ExtendedSettingsActivity.java
+++ b/src/sonyxperiadev/extendedsettings/ExtendedSettingsActivity.java
@@ -180,8 +180,13 @@ public class ExtendedSettingsActivity extends AppCompatPreferenceActivity {
         loadPref(m8MPSwitchPref, PREF_8MP_23MP_ENABLED);
         loadPref(mCameraAltAct, PREF_CAMERA_ALT_ACT);
 
-        initializeDRSListPreference();
-        findPreference(mDynamicResolutionSwitchPref).setOnPreferenceChangeListener(mPreferenceListener);
+        int ret = initializeDRSListPreference();
+        if(ret == 0) {
+            findPreference(mDynamicResolutionSwitchPref).setOnPreferenceChangeListener(mPreferenceListener);
+        } else {
+            getPreferenceScreen().removePreference(findPreference(mDynamicResolutionSwitchPref));
+        }
+
 
         String adbN = getSystemProperty(PREF_ADB_NETWORK_READ);
         boolean adbNB = isNumeric(adbN) && (Integer.parseInt(adbN) > 0);
@@ -362,7 +367,7 @@ public class ExtendedSettingsActivity extends AppCompatPreferenceActivity {
         return i;
     }
     
-    protected void initializeDRSListPreference() {
+    protected int initializeDRSListPreference() {
         DisplayParameters currentRes = sysfs_getCurrentResolution(0);
         ListPreference resPref = (ListPreference)findPreference(mDynamicResolutionSwitchPref);
         int i, curResVal;
@@ -384,10 +389,18 @@ public class ExtendedSettingsActivity extends AppCompatPreferenceActivity {
         }
 
         curResVal = resolutionToEntry(currentRes);
+
+        if(curResVal < 0) {
+            Log.e(TAG, "initializeDRSListPreference: Active mode is blank or cannot be detected." +
+                    " DRS will be disabled");
+            return -1;
+        }
+
         resPref.setDefaultValue(Integer.toString(curResVal));
         resPref.setValueIndex(curResVal);
 
         resPref.setSummary(sysfs_getCurrentResolutionString(0));
+        return 0;
     }
 
     protected static void performRRS(String modeString) {


### PR DESCRIPTION
If device only supports one mode, kernel will report blank mode through sysfs.
Detect such a case and disable DRS preference.

Change-Id: I55abaee8afa40f9e40cb254a841045350090c0b7